### PR TITLE
Add candle finalization with timing wheel and provisional flag

### DIFF
--- a/scripts/build_candles.sh
+++ b/scripts/build_candles.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+
+# Build script for candle C++ module
+# Usage: ./scripts/build_candles.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CANDLE_DIR="$PROJECT_ROOT/state/candle_cpp"
+BUILD_DIR="$CANDLE_DIR/build"
+
+echo "=================================================="
+echo "Building Candle C++ Module"
+echo "=================================================="
+
+# Create build directory
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+
+# Configure with CMake
+echo ""
+echo "Configuring CMake..."
+cmake ..
+
+# Build
+echo ""
+echo "Building..."
+cmake --build .
+
+echo ""
+echo "=================================================="
+echo "Build complete!"
+echo "=================================================="
+echo ""
+echo "Test binaries:"
+echo "  - $BUILD_DIR/tests/fixed_point_test"
+echo "  - $BUILD_DIR/tests/candle_finalize_test"
+echo ""
+echo "Run tests with:"
+echo "  cd $BUILD_DIR && ctest --output-on-failure"
+echo ""

--- a/state/candle_cpp/CMakeLists.txt
+++ b/state/candle_cpp/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.20)
+project(candle_cpp CXX)
+
+# C++20 standard
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Compiler flags
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
+
+# Include directories
+include_directories(include)
+
+# Source files
+set(CANDLE_SOURCES
+    src/fixed_point.cpp
+    src/candle_worker.cpp
+)
+
+# Create library
+add_library(candle_cpp STATIC ${CANDLE_SOURCES})
+
+# Fetch GoogleTest
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG v1.14.0
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+# Enable testing
+enable_testing()
+
+# Fixed point test
+add_executable(fixed_point_test tests/fixed_point_test.cpp)
+target_link_libraries(fixed_point_test candle_cpp GTest::gtest GTest::gtest_main pthread)
+add_test(NAME fixed_point_test COMMAND fixed_point_test)
+
+# Candle finalization test
+add_executable(candle_finalize_test tests/candle_finalize_test.cpp)
+target_link_libraries(candle_finalize_test candle_cpp GTest::gtest GTest::gtest_main pthread)
+add_test(NAME candle_finalize_test COMMAND candle_finalize_test)

--- a/state/candle_cpp/tests/candle_finalize_test.cpp
+++ b/state/candle_cpp/tests/candle_finalize_test.cpp
@@ -1,0 +1,177 @@
+#include <gtest/gtest.h>
+#include <thread>
+#include <chrono>
+#include "candle_worker.hpp"
+#include "fixed_point.hpp"
+
+using namespace candle;
+
+// ============================================================================
+// Candle Finalization Tests
+// ============================================================================
+
+TEST(CandleFinalizeTest, ProvisionialFlagInitiallyTrue) {
+    Candle candle;
+    EXPECT_TRUE(candle.provisional);
+}
+
+TEST(CandleFinalizeTest, WatermarkUpdatesOnTrade) {
+    CandleWindow window(WindowSize::MIN_1, "SOL/USDC");
+
+    uint64_t timestamp1 = 1700000060;
+    uint64_t timestamp2 = 1700000065;
+
+    FixedPrice price = FixedPoint::from_double(100.0).raw();
+    FixedPrice volume = FixedPoint::from_double(10.0).raw();
+
+    window.update(timestamp1, price, volume, volume);
+    EXPECT_EQ(window.last_trade_time, timestamp1);
+
+    window.update(timestamp2, price, volume, volume);
+    EXPECT_EQ(window.last_trade_time, timestamp2);
+}
+
+TEST(CandleFinalizeTest, FinalizeOldCandlesFlipsProvisionalFlag) {
+    CandleWindow window(WindowSize::MIN_1, "SOL/USDC");
+
+    // Create a candle at timestamp 1700000060 (window: 1700000040-1700000100)
+    uint64_t timestamp = 1700000060;
+    FixedPrice price = FixedPoint::from_double(100.0).raw();
+    FixedPrice volume = FixedPoint::from_double(10.0).raw();
+
+    window.update(timestamp, price, volume, volume);
+
+    // Check candle exists and is provisional
+    {
+        std::lock_guard<std::mutex> lock(window.mutex);
+        uint64_t window_start = window.get_window_start(timestamp);
+        ASSERT_TRUE(window.candles.find(window_start) != window.candles.end());
+        EXPECT_TRUE(window.candles[window_start].provisional);
+    }
+
+    // Finalize with watermark after window close time
+    uint64_t watermark = 1700000100;
+    auto finalized = window.finalize_old_candles(watermark);
+
+    // Should have finalized one candle
+    ASSERT_EQ(finalized.size(), 1);
+    EXPECT_FALSE(finalized[0].provisional);
+    EXPECT_EQ(finalized[0].open_time, 1700000040);
+    EXPECT_EQ(finalized[0].close_time, 1700000100);
+
+    // Window should be cleared after finalization
+    {
+        std::lock_guard<std::mutex> lock(window.mutex);
+        uint64_t window_start = window.get_window_start(timestamp);
+        EXPECT_TRUE(window.candles.find(window_start) == window.candles.end());
+    }
+}
+
+TEST(CandleFinalizeTest, DoesNotFinalizeCurrentWindow) {
+    CandleWindow window(WindowSize::MIN_1, "SOL/USDC");
+
+    // Create a candle at timestamp 1700000060 (window: 1700000040-1700000100)
+    uint64_t timestamp = 1700000060;
+    FixedPrice price = FixedPoint::from_double(100.0).raw();
+    FixedPrice volume = FixedPoint::from_double(10.0).raw();
+
+    window.update(timestamp, price, volume, volume);
+
+    // Finalize with watermark BEFORE window close time
+    uint64_t watermark = 1700000080;
+    auto finalized = window.finalize_old_candles(watermark);
+
+    // Should NOT finalize (window still open)
+    EXPECT_EQ(finalized.size(), 0);
+
+    // Candle should still exist
+    {
+        std::lock_guard<std::mutex> lock(window.mutex);
+        uint64_t window_start = window.get_window_start(timestamp);
+        ASSERT_TRUE(window.candles.find(window_start) != window.candles.end());
+        EXPECT_TRUE(window.candles[window_start].provisional);
+    }
+}
+
+TEST(CandleFinalizeTest, WorkerEmitsFinalizedCandles) {
+    CandleWorker worker(4);
+    worker.start();
+
+    // Send trades
+    uint64_t base_time = std::chrono::duration_cast<std::chrono::seconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count() - 120;
+
+    FixedPrice price = FixedPoint::from_double(100.0).raw();
+    FixedPrice volume = FixedPoint::from_double(10.0).raw();
+
+    // Trade in a window that should close soon
+    worker.on_trade("SOL/USDC", base_time, price, volume, volume);
+
+    // Wait for timing wheel to finalize (1s tick + buffer)
+    std::this_thread::sleep_for(std::chrono::seconds(3));
+
+    // Check emitted candles
+    auto emitted = worker.get_emitted_candles();
+
+    // Should have emitted at least the 1m window candle
+    // (may have more from other window sizes)
+    EXPECT_GT(emitted.size(), 0);
+
+    // Find the 1m candle
+    bool found_1m_candle = false;
+    for (const auto& candle : emitted) {
+        if (candle.open_time <= base_time && candle.close_time > base_time) {
+            EXPECT_FALSE(candle.provisional);
+            EXPECT_EQ(candle.trades, 1);
+            found_1m_candle = true;
+        }
+    }
+
+    EXPECT_TRUE(found_1m_candle);
+
+    worker.stop();
+}
+
+TEST(CandleFinalizeTest, MultipleWindowsFinalized) {
+    CandleWindow window(WindowSize::MIN_1, "SOL/USDC");
+
+    // Create multiple candles in different windows
+    uint64_t base_time = 1700000000;
+    FixedPrice price = FixedPoint::from_double(100.0).raw();
+    FixedPrice volume = FixedPoint::from_double(10.0).raw();
+
+    // Window 1: 1700000000-1700000060
+    window.update(base_time + 10, price, volume, volume);
+
+    // Window 2: 1700000060-1700000120
+    window.update(base_time + 70, price, volume, volume);
+
+    // Window 3: 1700000120-1700000180
+    window.update(base_time + 130, price, volume, volume);
+
+    // Finalize windows 1 and 2
+    uint64_t watermark = base_time + 120;
+    auto finalized = window.finalize_old_candles(watermark);
+
+    // Should finalize 2 windows
+    ASSERT_EQ(finalized.size(), 2);
+
+    for (const auto& candle : finalized) {
+        EXPECT_FALSE(candle.provisional);
+    }
+
+    // Window 3 should still exist
+    {
+        std::lock_guard<std::mutex> lock(window.mutex);
+        EXPECT_EQ(window.candles.size(), 1);
+    }
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Implements a lightweight timing wheel that runs every 1 second to finalize 1-minute candle windows when no new trades arrive. Key changes:

- Add provisional flag to Candle struct (true until finalized)
- Add last_trade_time watermark to CandleWindow for tracking
- Implement finalize_old_candles() to mark windows closed and emit them
- Add background finalize_thread_ that runs finalize_loop() every 1s
- Hook timing wheel into start()/stop() lifecycle methods
- Emit finalized candles to in-memory sink for testing
- Add get_emitted_candles() API for test validation

Tests cover:
- Provisional flag initialization and flipping on finalization
- Watermark updates on trade ingestion
- Window state clearing after finalization
- End-to-end worker emission with timing wheel
- Multiple window finalization in one sweep

Build system:
- Add CMakeLists.txt with GoogleTest FetchContent integration
- Create scripts/build_candles.sh for cmake build + test run
- Update README.md with watermark behavior documentation

All 6 candle finalization tests pass successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)